### PR TITLE
Add Finnish locale for Paperbuzz Plugin

### DIFF
--- a/locale/fi_FI/locale.xml
+++ b/locale/fi_FI/locale.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * @file plugins/generic/paperbuzz/locale/fi_FI/locale.xml
+  *
+  * Copyright (c) 2013-2019 Simon Fraser University
+  * Copyright (c) 2003-2019 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Paperbuzz plugin localization strings
+  -->
+
+<locale name="fi_FI" full_name="Suomi">
+	<message key="plugins.generic.paperbuzz.displayName">Paperbuzz -lisäosa</message>
+	<message key="plugins.generic.paperbuzz.description">Näyttää artikkelin käyttötilastot abstraktisivulla. Mikäli artikkelilla ei ole DOI-tunnusta, näkyy ainoastaan artikkelin latausmäärä.</message>
+	<message key="plugins.generic.paperbuzz.metrics">Tilastot</message>
+	<message key="plugins.generic.paperbuzz.loading">Tilastoja ladataan ...</message>
+
+	<message key="plugins.generic.paperbuzz.settings">Asetukset</message>
+	<message key="plugins.generic.paperbuzz.settings.apiEmail">Sähköposti</message>
+	<message key="plugins.generic.paperbuzz.settings.apiEmail.description">Sähköposti vaaditaan Paperbuzz-palvelun käyttöön.</message>
+	<message key="plugins.generic.paperbuzz.settings.apiEmail.required">Sähköposti vaaditaan.</message>
+	<message key="plugins.generic.paperbuzz.settings.graph.description">Näytä käyttötilastoja koskevat kuvaajat tai pelkstään luvut.</message>
+	<message key="plugins.generic.paperbuzz.settings.showGraph">Näytä kuvaajat</message>
+	<message key="plugins.generic.paperbuzz.settings.showMini">Näytä pelkät luvut</message>
+	<message key="plugins.generic.paperbuzz.settings.downloads">Latauksia</message>
+	<message key="plugins.generic.paperbuzz.settings.hideDownloads">Piilota artikkelin latausmäärät, näytä vain Paperbuzz-palvelun tilastot.</message>
+	<message key="plugins.generic.paperbuzz.sourceName.pdf">PDF-latauksia</message>
+	<message key="plugins.generic.paperbuzz.sourceName.html">HTML-latauksia</message>
+	<message key="plugins.generic.paperbuzz.sourceName.other">Muiden tiedostomuotojen latauksia</message>
+</locale>


### PR DESCRIPTION
I almost translated "Paperbuzz" to "Paperipöhinä".