### PR TITLE
Use Guzzle and update to next version

### DIFF
--- a/PaperbuzzSettingsForm.inc.php
+++ b/PaperbuzzSettingsForm.inc.php
@@ -36,7 +36,8 @@ class PaperbuzzSettingsForm extends Form {
 	/**
 	 * @copydoc Form::initData()
 	 */
-	function initData($request) {
+	function initData() {
+		$request = Application::get()->getRequest();
 		$context = $request->getContext();
 		if ($context) {
 			$plugin = $this->plugin;
@@ -60,7 +61,7 @@ class PaperbuzzSettingsForm extends Form {
 	/**
 	 * @copydoc Form::fetch()
 	 */
-	function fetch($request) {
+	function fetch($request, $template = NULL, $display = false) {
 		$plugin = $this->plugin;
 		$showMiniOptions = array(
 			false => __('plugins.generic.paperbuzz.settings.showGraph'),
@@ -76,7 +77,8 @@ class PaperbuzzSettingsForm extends Form {
 	 * Save settings.
 	 * @copydoc Form::execute()
 	 */
-	function execute($request) {
+	function execute(...$functionArgs) {
+		$request = Application::get()->getRequest();
 		$context = $request->getContext();
 		if ($context) {
 			$plugin = $this->plugin;

--- a/version.xml
+++ b/version.xml
@@ -14,8 +14,8 @@
 <version>
 	<application>paperbuzz</application>
 	<type>plugins.generic</type>
-	<release>1.0.2.0</release>
-	<date>2020-06-19</date>
+	<release>1.0.3.0</release>
+	<date>2021-02-02</date>
 	<lazy-load>1</lazy-load>
 	<class>PaperbuzzPlugin</class>
 </version>


### PR DESCRIPTION
The PR removes CURL and uses Guzzle instead. The version is updated to the next minor one, that will be packed and provided for the OJS 3.3.0.2 via plugin gallery.